### PR TITLE
Fix: Error when there is no beam peak or chisquare file uploaded

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,8 +30,23 @@ networks:
 
 volumes:
   django_media:
-  django_static:
+    # driver: local
+    # driver_opts:
+    #   type: "none"
+    #   o: "bind"
+    #   device: "<path-to-volume>/django_media"
   postgres_data:
+    # driver: local
+    # driver_opts:
+    #   type: "none"
+    #   o: "bind"
+    #   device: "<path-to-volume>/postgres_data"
+  django_static:
+    # driver: local
+    # driver_opts:
+    #   type: "none"
+    #   o: "bind"
+    #   device: "<path-to-volume>/postgres_data"
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,17 @@ networks:
 
 volumes:
   django_media:
+    # driver: local
+    # driver_opts:
+    #   type: "none"
+    #   o: "bind"
+    #   device: "<path-to-volume>/django_media"
   postgres_data:
+    # driver: local
+    # driver_opts:
+    #   type: "none"
+    #   o: "bind"
+    #   device: "<path-to-volume>/postgres_data"
 
 services:
   db:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,8 @@ To shutdown the containers:
 
 ## Production
 
+### Environment variables
+
 Starting the production version of the webapp is similar to the above. However before deploying, there are a number of variables to change in the `docker-compose.prod.yml` file. These variables are the following:
 
 - DJANGO_ALLOWED_HOSTS: Add your production url here, for example, `ywangvaster.duckdns.org`. These are the domains that are allowed be used to access the webapp.
@@ -30,6 +32,32 @@ Starting the production version of the webapp is similar to the above. However b
 - DJANGO_SUPERUSER_PASSWORD: A strong password is recommended. More than 16 characters, mixed with numbers, symbols, lowercase and uppercase.
 - DJANGO_SUPERUSER_EMAIL: An email address that users can send emails to if they come across issues with the webapp.
 - DJANGO_SECRET_KEY: A complex key with many different numbers, letters, and capitals.
+
+### Volumes
+
+If you wish to have the data for the webapp stored in a specific location on the host machine, please make sure you follow these steps:
+
+1. Create a folder for postgres_data, django_media and django_static using the following commands
+
+```bash
+mkdir -p django_media
+sudo chown -R 999:999 django_media
+```
+
+2. Uncomment the type, bind and device paramters in the docker-compose.prod.yml and set your path to the folders that were just created, for example:
+
+```bash
+volumes:
+  django_media:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /data/vaster_webapp/volumes/django_media
+```
+
+### Starting the webapp
+
 
 To start the production version of the webapp, you will to run the following command:
 

--- a/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
+++ b/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
@@ -167,6 +167,14 @@
                             style="fill: #1c1b1e" />
                         </svg></button></a>
                   </div>
+                  {% else %}
+                  <div><button type="button" class='btn btn-secondary' data-toggle="tooltip" data-placement="left" title="File unavailable">SLICES FITS
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                      <path
+                        d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                        style="fill: #1c1b1e" />
+                    </svg></button>
+                  </div>
                   {% endif %}
 
                   {% if candidate.deepcutout_fits %}
@@ -177,6 +185,14 @@
                             d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
                             style="fill: #1c1b1e" />
                         </svg></button></a>
+                  </div>
+                  {% else %}
+                  <div><button type="button" class='btn btn-secondary' data-toggle="tooltip" data-placement="left" title="File unavailable">DEEPCUT FITS
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                      <path
+                        d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                        style="fill: #1c1b1e" />
+                    </svg></button>
                   </div>
                   {% endif %}
                   {% if candidate.lightcurve_data %}
@@ -190,6 +206,16 @@
                         </svg>
                       </button>
                     </a>
+                  </div>
+                  {% else %}
+                  <div>
+                    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="File unavailable">LIGHTCURVE CSV
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                          <path
+                            d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                            style="fill: #1c1b1e" />
+                        </svg>
+                    </button>
                   </div>
                   {% endif %}
                 </div>
@@ -507,6 +533,17 @@
                       </button>
                     </a>
                   </div>
+                  {% else %}
+                  <div>
+                    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="File unavailable">STD
+                        FITS
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                          <path
+                            d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                            style="fill: #1c1b1e" />
+                        </svg>
+                      </button>
+                  </div>
                   {% endif %}
                   {% if candidate.beam.peak_fits %}
                   <div>
@@ -520,6 +557,17 @@
                       </button>
                     </a>
                   </div>
+                  {% else %}
+                  <div>
+                    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="File unavailable">PEAK
+                        FITS
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                          <path
+                            d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                            style="fill: #1c1b1e" />
+                        </svg>
+                      </button>
+                  </div>
                   {% endif %}
                   {% if candidate.beam.chisquare_fits %}
                   <div>
@@ -532,6 +580,17 @@
                         </svg>
                       </button>
                     </a>
+                  </div>
+                  {% else %}
+                  <div>
+                    <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="left" title="File unavailable">CHISQUARE
+                        FITS
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+                          <path
+                            d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"
+                            style="fill: #1c1b1e" />
+                        </svg>
+                      </button>
                   </div>
                   {% endif %}
                 </div>

--- a/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
+++ b/ywangvaster_webapp/templates/candidate_app/candidate_rating.html
@@ -508,7 +508,7 @@
                     </a>
                   </div>
                   {% endif %}
-                  {% if candidate.beam.peak_fits.url %}
+                  {% if candidate.beam.peak_fits %}
                   <div>
                     <a href="{{ candidate.beam.peak_fits.url }}"><button class='btn btn-primary'>PEAK
                         FITS
@@ -521,7 +521,7 @@
                     </a>
                   </div>
                   {% endif %}
-                  {% if candidate.beam.chisquare_fits.url %}
+                  {% if candidate.beam.chisquare_fits %}
                   <div>
                     <a href="{{ candidate.beam.chisquare_fits.url }}"><button class='btn btn-primary'>CHISQUARE
                         FITS


### PR DESCRIPTION
This PR fixes the candidate rating page when there is no beam peak or chisquare file uploaded to the DB. The buttons will now be grey if no file is present and a tooltip will appear on hover over to let the user know. 

![image](https://github.com/user-attachments/assets/1767af1c-cb30-4175-b521-7250706215b8)

I have also quickly added to the docker config files to have the volumes for the webapp stored in a bind mount to a local directory. The user that deploys the webapp will just have to ensure the bind path is set correctly before starting webapp. 